### PR TITLE
fix(x-ui): convert expiry_time from milliseconds to seconds

### DIFF
--- a/x-ui/migration/transformers/converter.py
+++ b/x-ui/migration/transformers/converter.py
@@ -156,6 +156,9 @@ class DataConverter:
         if transform_func == "enable_to_status":
             enable = value
             expiry_time = row.get("expiry_time", 0)
+            # x-ui stores expiry_time in milliseconds; convert to seconds
+            if expiry_time and expiry_time > 1e10:
+                expiry_time = expiry_time / 1000.0
             data_limit = row.get("total", 0)  # x-ui uses 'total' for data limit
             used_traffic = (row.get("up", 0) or 0) + (row.get("down", 0) or 0)
             
@@ -185,7 +188,9 @@ class DataConverter:
         elif transform_func == "expiry_time_to_expire":
             if value and value > 0:
                 try:
-                    return datetime.fromtimestamp(value, tz=timezone.utc)
+                    # x-ui stores expiry_time in milliseconds; convert to seconds
+                    timestamp_seconds = value / 1000.0 if value > 1e10 else value
+                    return datetime.fromtimestamp(timestamp_seconds, tz=timezone.utc)
                 except (ValueError, OSError):
                     return None
             return None
@@ -257,6 +262,9 @@ class DataConverter:
             if "status" not in converted:
                 enable = source_row.get("enable", 1)
                 expiry_time = source_row.get("expiry_time", 0)
+                # x-ui stores expiry_time in milliseconds; convert to seconds
+                if expiry_time and expiry_time > 1e10:
+                    expiry_time = expiry_time / 1000.0
                 data_limit = source_row.get("total", 0)
                 used_traffic = converted.get("used_traffic", 0)
                 


### PR DESCRIPTION
## Problem

When migrating users from x-ui (SQLite3), all expiration dates become **unlimited** — only traffic quotas are migrated correctly.

**Root cause:** x-ui stores `expiry_time` in **milliseconds**, but the converter passes the raw value directly to `datetime.fromtimestamp()`, which expects **seconds**. A millisecond timestamp like `1704067200000` causes an `OSError` (out of range), which is caught and returns `None` — meaning unlimited expiration.

The same unit mismatch also affects status detection: comparing a millisecond `expiry_time` against `now_ts` in seconds means `1704067200000 < 1744329600` is always `False`, so expired users are never detected as expired.

The codebase already handles this correctly for `last_online` timestamps:
```python
timestamp_seconds = value / 1000.0 if value > 1e10 else value
```

## Fix

Apply the same ms-to-seconds conversion to `expiry_time` in three locations:

1. **`expiry_time_to_expire` transform** — the `expire` datetime field itself
2. **`enable_to_status` transform** — expiry-based status detection
3. **`_add_default_values` status fallback** — same comparison when status not yet set

## Testing

Verified all paths with 12 test cases:

| Test | Scenario | Result |
|---|---|---|
| `expiry_time_to_expire` | ms timestamp (1744329600000) | Correct datetime |
| `expiry_time_to_expire` | seconds timestamp (1744329600) | Still works (no regression) |
| `expiry_time_to_expire` | 0 (unlimited) | Returns None |
| `enable_to_status` | enabled + past ms expiry | `expired` |
| `enable_to_status` | enabled + future ms expiry | `active` |
| `enable_to_status` | disabled + past ms expiry | `expired` |
| `enable_to_status` | enabled + no expiry | `active` |
| `enable_to_status` | over data limit | `limited` |
| `_add_default_values` | fallback past ms | `expired` |
| `_add_default_values` | fallback future ms | `active` |

Closes PasarGuard/panel#287

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of expiration timestamps stored in milliseconds format during data migration. The system now correctly converts these timestamps to seconds, ensuring accurate status evaluations and proper date/time calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->