### PR TITLE
fix(x-ui): fix OOM crash in generate_subscription_url_mapping for large deployments

### DIFF
--- a/x-ui/migration/generate_subscription_url_mapping.py
+++ b/x-ui/migration/generate_subscription_url_mapping.py
@@ -225,14 +225,37 @@ def generate_subscription_url_mapping(
         cursor = xui_conn.cursor()
         if xui_user_table not in ['client_traffics', 'clients']:
             raise ValueError(f"Invalid table name: {xui_user_table}")
-        
-        # First, check what columns are available in client_traffics
+
+        logger.info("Pre-loading subIds from inbounds...")
+        cursor.execute("SELECT id, settings FROM inbounds")
+        inbound_subid_map: dict[tuple, str] = {}
+        inbound_count = 0
+        for ib_row in cursor:
+            inbound_count += 1
+            raw = ib_row['settings']
+            if not raw:
+                logger.debug(f"Inbound {ib_row['id']} has empty settings, skipping")
+                continue
+            try:
+                ib_settings = json.loads(raw) if isinstance(raw, str) else raw
+                for client in ib_settings.get('clients', []):
+                    client_email = client.get('email', '').strip()
+                    sub_id = (
+                        client.get('subId') or client.get('sub_id') or
+                        client.get('sub_token') or client.get('subscription_token') or
+                        client.get('token') or client.get('sub')
+                    )
+                    if client_email and sub_id:
+                        inbound_subid_map[(ib_row['id'], client_email)] = sub_id
+            except (json.JSONDecodeError, AttributeError) as e:
+                logger.warning(f"Failed to parse settings for inbound {ib_row['id']}: {e}")
+        logger.info(f"  Built subId map: {len(inbound_subid_map)} entries across {inbound_count} inbounds")
+
         cursor.execute(f"PRAGMA table_info(`{xui_user_table}`)")
         columns = [row[1] for row in cursor.fetchall()]
         logger.debug(f"Available columns in {xui_user_table}: {columns}")
-        
-        # Try to select subscription token if it exists (common names: sub_token, subscription_token, token, sub)
-        select_fields = ["ct.id", "ct.email", "ct.inbound_id", "i.settings as inbound_settings"]
+
+        select_fields = ["ct.id", "ct.email", "ct.inbound_id"]
         if 'sub_token' in columns:
             select_fields.append("ct.sub_token")
         elif 'subscription_token' in columns:
@@ -241,11 +264,10 @@ def generate_subscription_url_mapping(
             select_fields.append("ct.token")
         elif 'sub' in columns:
             select_fields.append("ct.sub")
-        
+
         cursor.execute(f"""
             SELECT {', '.join(select_fields)}
             FROM `{xui_user_table}` ct
-            LEFT JOIN inbounds i ON ct.inbound_id = i.id
             ORDER BY ct.id
         """)
         xui_users = cursor.fetchall()
@@ -302,8 +324,7 @@ def generate_subscription_url_mapping(
             email = xui_user['email']
             xui_user_id = xui_user['id']
             inbound_id = xui_user['inbound_id']
-            inbound_settings = xui_user['inbound_settings']
-            
+
             old_url = None
             subscription_token = None
             for token_field in ['sub_token', 'subscription_token', 'token', 'sub']:
@@ -314,14 +335,12 @@ def generate_subscription_url_mapping(
                         break
                 except (KeyError, IndexError):
                     continue
-            
-            if inbound_settings:
-                sub_id = extract_subscription_token_from_inbound(inbound_settings, email)
-                if sub_id:
-                    subscription_token = sub_id
-            
+
+            if not subscription_token and email and inbound_id is not None:
+                subscription_token = inbound_subid_map.get((inbound_id, email))
+
             if not subscription_token:
-                logger.warning(f"No subscription token (subId) found for user {email} (ID: {xui_user_id}). Skipping...")
+                logger.debug(f"No subId for user '{email}' (ID: {xui_user_id}, inbound: {inbound_id})")
                 not_found[email if email else f"user_{xui_user_id}"] = {
                     "user_id": xui_user_id,
                     "reason": "No subscription token (subId) found in inbound settings"

--- a/x-ui/migration/generate_subscription_url_mapping.py
+++ b/x-ui/migration/generate_subscription_url_mapping.py
@@ -265,12 +265,15 @@ def generate_subscription_url_mapping(
         elif 'sub' in columns:
             select_fields.append("ct.sub")
 
-        cursor.execute(f"""
+        cursor.execute(f"SELECT COUNT(*) FROM `{xui_user_table}`")
+        total_xui_users = cursor.fetchone()[0]
+
+        xui_cursor = xui_conn.cursor()
+        xui_cursor.execute(f"""
             SELECT {', '.join(select_fields)}
             FROM `{xui_user_table}` ct
             ORDER BY ct.id
         """)
-        xui_users = cursor.fetchall()
         
         logger.info("Fetching users from Pasarguard...")
         cursor = pasarguard_conn.cursor()
@@ -316,10 +319,10 @@ def generate_subscription_url_mapping(
         matched_by_email = 0
         matched_by_id = 0
         
-        logger.info(f"Processing {len(xui_users)} users...")
-        for idx, xui_user in enumerate(xui_users, 1):
-            if idx % 100 == 0 or idx == len(xui_users):
-                logger.info(f"  Processed {idx}/{len(xui_users)} users...")
+        logger.info(f"Processing {total_xui_users} users...")
+        for idx, xui_user in enumerate(xui_cursor, 1):
+            if idx % 100 == 0 or idx == total_xui_users:
+                logger.info(f"  Processed {idx}/{total_xui_users} users...")
             
             email = xui_user['email']
             xui_user_id = xui_user['id']
@@ -408,7 +411,7 @@ def generate_subscription_url_mapping(
         
         result = {
             "generated_at": time.strftime("%Y-%m-%d %H:%M:%S"),
-            "total_users": len(xui_users),
+            "total_users": total_xui_users,
             "mapped_users": len(mappings),
             "not_found_users": len(not_found),
             "panel": "x-ui",


### PR DESCRIPTION
## Problem

On large x-ui deployments (10k+ users), `generate_subscription_url_mapping.py` is killed by the OOM killer (exit code 137 / SIGKILL) and produces no output file. The script appears to start (`Fetching users from x-ui...`) but then silently dies.

### Root cause

The query does a `LEFT JOIN` between `client_traffics` and `inbounds`:

```sql
SELECT ct.id, ct.email, ct.inbound_id, i.settings AS inbound_settings
FROM client_traffics ct
LEFT JOIN inbounds i ON ct.inbound_id = i.id
```

The `inbounds.settings` column contains a JSON blob that embeds **all clients** for that inbound (can be 3,500+ clients, ~7 MB per inbound). Joining this into `client_traffics` and calling `fetchall()` duplicates the full blob for every user row.

Example: 10,654 users × 3 inbounds × ~7 MB per inbound ≈ **~75 GB** resident memory → OOM kill before any output is written.

## Fix

Pre-load an `email → subId` dict by reading each inbound's settings JSON **once** (O(inbounds) passes), then query `client_traffics` without the `LEFT JOIN` and do an O(1) dict lookup per user.

Memory usage drops from **O(users × inbound_json_size)** to **O(inbounds × inbound_json_size + users)**.

The existing `extract_subscription_token_from_inbound()` helper is no longer called in the hot path (it is still used by the per-row branch for deployments that store the token directly on the client_traffics row).

## Test results

Tested on a real production deployment:

| | Before | After |
|---|---|---|
| Users | 10,654 | 10,654 |
| Inbounds | 3 | 3 |
| RAM | 2 GB (no swap) | 2 GB (no swap) |
| Result | OOM killed after ~5 s, no output | Completes in ~3 s, 10,652 mappings generated |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved subscription URL mapping generation process for better performance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PasarGuard/migrations/pull/4?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->